### PR TITLE
Allow application to optionally load OpenSSL

### DIFF
--- a/U_DCS_OAuth2.pas
+++ b/U_DCS_OAuth2.pas
@@ -598,8 +598,13 @@ var
 begin
   result := '';
 
-  LoadOpenSSLLibrary;
-  if not TIdHashSHA256.IsAvailable then raise Exception.Create('Error encode_SHA256_base64URL: TIdHashSHA256 not available.');
+  // Load OpenSSL if not already loaded by the application
+  if not TIdHashSHA256.IsAvailable then
+    begin
+    LoadOpenSSLLibrary;
+    if not TIdHashSHA256.IsAvailable then
+      raise Exception.Create('Error encode_SHA256_base64URL: TIdHashSHA256 not available.');
+    end;
 
   hash_sha256 := TIdHashSHA256.Create;
   enc_base64 := TBase64Encoding.Create(0);


### PR DESCRIPTION
Load OpenSSL only if not already loaded. This allows for the application to optionally load its own version of OpenSSL. For example, an application may want to use the newer OpenSSL.

See issue: #6 